### PR TITLE
Add migration sort helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add migration sort helper (#7)
+
 ## v0.2.0
 
 - Add key prefix as mandatory parameter (#5)

--- a/migrate.go
+++ b/migrate.go
@@ -8,8 +8,18 @@ import (
 
 type RedisUpFunc = func(ctx context.Context, client *redis.Client) error
 
+// RedisMigration is a single migration to be run on a database.
 type RedisMigration struct {
+	// ID is the identifier of this migration. It is used by the
+	// framework to keep track of pending and finished migrations.
+	//
+	// It is recommended that you use something like "00000001-init" and
+	// "00000002-next-migration" as identifier since this format allows you
+	// to both sort your migrations based on the ID (see SortMigrationsByID) and
+	// generally identify what your migration does.
 	ID string
+
+	// Up is the function implementing the actual migration logic.
 	Up RedisUpFunc
 }
 

--- a/sort.go
+++ b/sort.go
@@ -1,0 +1,34 @@
+package kvmigrator
+
+import (
+	"slices"
+	"strings"
+)
+
+// SortMigrationsByID sorts the given migrations based on comparing their IDs.
+//
+// strings.Compare is used as comparator. Look at the tests of this function if you
+// want to see examples of how this is sorted.
+//
+// The input slice is not modified in-place but instead a new, sorted slice is returned.
+//
+// Once this module reaches v1 its sorting algorithm should not be changed.
+func SortMigrationsByID(migrations []*RedisMigration) []*RedisMigration {
+	return SortRedisMigrations(migrations, func(a, b *RedisMigration) int {
+		return strings.Compare(a.ID, b.ID)
+	})
+}
+
+// SortRedisMigrations is a helper function to sort the given migrations. You can
+// supply your own comparator function to be used for sorting.
+//
+// The input slice is not modified in-place but instead a new, sorted slice is returned.
+func SortRedisMigrations(migrations []*RedisMigration, cmp func(a, b *RedisMigration) int) []*RedisMigration {
+	// clone slice
+	migrations = slices.Clone(migrations)
+
+	// sort slice
+	slices.SortFunc(migrations, cmp)
+
+	return migrations
+}

--- a/sort_test.go
+++ b/sort_test.go
@@ -1,0 +1,93 @@
+package kvmigrator
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSortMigrationsByID(t *testing.T) {
+	data := dataTestSortMigrationsByID()
+
+	for i, data := range data {
+		t.Run(fmt.Sprintf("dataset %d", i), func(t *testing.T) {
+			input := data.input
+			sorted := SortMigrationsByID(input)
+			assert.NotSame(t, input, sorted, "sorted slice is the same as input slice")
+			assert.Equal(t, len(input), len(sorted), "sorted slice has unexpected length")
+
+			for id, index := range data.expected {
+				assert.Equal(t, id, sorted[index].ID, "unexpected migration at index %d", index)
+			}
+		})
+	}
+}
+
+type datasetTestSortMigrationsByID struct {
+	input    []*RedisMigration
+	expected map[string]int
+}
+
+func dataTestSortMigrationsByID() []*datasetTestSortMigrationsByID {
+	var data []*datasetTestSortMigrationsByID
+
+	data = append(data, &datasetTestSortMigrationsByID{
+		input: []*RedisMigration{
+			{ID: "05-z"},
+			{ID: "01-c"},
+			{ID: "01-m"},
+			{ID: "05-a"},
+			{ID: "03-a"},
+		},
+		expected: map[string]int{
+			"01-c": 0,
+			"01-m": 1,
+			"03-a": 2,
+			"05-a": 3,
+			"05-z": 4,
+		},
+	})
+
+	data = append(data, &datasetTestSortMigrationsByID{
+		input: []*RedisMigration{
+			{ID: "001-a"},
+			{ID: "002-a"},
+			{ID: "01-a"},
+		},
+		expected: map[string]int{
+			"001-a": 0,
+			"002-a": 1,
+			"01-a":  2,
+		},
+	})
+
+	data = append(data, &datasetTestSortMigrationsByID{
+		input: []*RedisMigration{
+			{ID: "001-a"},
+			{ID: "002-a"},
+			{ID: "0001-a"},
+		},
+		expected: map[string]int{
+			"0001-a": 0,
+			"001-a":  1,
+			"002-a":  2,
+		},
+	})
+
+	data = append(data, &datasetTestSortMigrationsByID{
+		input: []*RedisMigration{
+			{ID: "002-b"},
+			{ID: "001-a-1"},
+			{ID: "002-a"},
+			{ID: "001-a-2"},
+		},
+		expected: map[string]int{
+			"001-a-1": 0,
+			"001-a-2": 1,
+			"002-a":   2,
+			"002-b":   3,
+		},
+	})
+
+	return data
+}


### PR DESCRIPTION
This PR adds a helper function to sort migrations. Running migrations in the correct order is important and thus one should use.

Related to #3